### PR TITLE
change README.md example to function correctly and match blog code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const octokit = new Octokit({
 });
 
 const content = fs.readFileSync('file/to/path', 'utf-8');
-const fileOutput = Base64.encode(content);
+const contentEncoded = Base64.encode(content);
 
 const { data } = await octokit.repos.createOrUpdateFileContents({
   owner: 'okeeffed',


### PR DESCRIPTION
#### Issue
The second code example for adding a file to GitHub uses an undefined variable for the content.

#### Fix
Changed the variable name for the encoded file to `contentEncoded` to both fix the code and match the code on the referencing blog page.